### PR TITLE
Fluent Reward Generator

### DIFF
--- a/src/main/java/com/soapboxrace/core/api/DriverPersona.java
+++ b/src/main/java/com/soapboxrace/core/api/DriverPersona.java
@@ -106,7 +106,7 @@ public class DriverPersona {
     @Produces(MediaType.APPLICATION_XML)
     public String deletePersona(@QueryParam("personaId") Long personaId,
                                 @HeaderParam("securityToken") String securityToken) {
-        tokenSessionBo.verifyPersona(securityToken, personaId);
+        tokenSessionBo.verifyPersonaOwnership(securityToken, personaId);
         driverPersonaBO.deletePersona(personaId);
         return "<long>0</long>";
     }
@@ -152,7 +152,7 @@ public class DriverPersona {
     public PersonaMotto updateStatusMessage(InputStream statusXml, @HeaderParam("securityToken") String securityToken
             , @Context Request request) {
         PersonaMotto personaMotto = UnmarshalXML.unMarshal(statusXml, PersonaMotto.class);
-        tokenSessionBo.verifyPersona(securityToken, personaMotto.getPersonaId());
+        tokenSessionBo.verifyPersonaOwnership(securityToken, personaMotto.getPersonaId());
 
         driverPersonaBO.updateStatusMessage(personaMotto.getMessage(), personaMotto.getPersonaId());
         return personaMotto;

--- a/src/main/java/com/soapboxrace/core/api/Personas.java
+++ b/src/main/java/com/soapboxrace/core/api/Personas.java
@@ -48,7 +48,7 @@ public class Personas {
     public CommerceSessionResultTrans commerce(InputStream commerceXml,
                                                @HeaderParam("securityToken") String securityToken,
                                                @PathParam(value = "personaId") Long personaId) {
-        sessionBO.verifyPersona(securityToken, personaId);
+        sessionBO.verifyPersonaOwnership(securityToken, personaId);
         String xml = new BufferedReader(new InputStreamReader(commerceXml))
                 .lines().collect(Collectors.joining(""));
         CommerceSessionTrans commerceSessionTrans = UnmarshalXML.unMarshal(xml, CommerceSessionTrans.class);
@@ -62,7 +62,7 @@ public class Personas {
     @Produces(MediaType.APPLICATION_XML)
     public CommerceResultTrans baskets(@HeaderParam("securityToken") String securityToken, InputStream basketXml,
                                        @PathParam(value = "personaId") Long personaId) {
-        sessionBO.verifyPersona(securityToken, personaId);
+        sessionBO.verifyPersonaOwnership(securityToken, personaId);
 
         PersonaEntity personaEntity = personaBO.getPersonaById(personaId);
 
@@ -127,7 +127,7 @@ public class Personas {
     @Produces(MediaType.APPLICATION_XML)
     public CarSlotInfoTrans carslots(@PathParam(value = "personaId") Long personaId,
                                      @HeaderParam("securityToken") String securityToken) {
-        sessionBO.verifyPersona(securityToken, personaId);
+        sessionBO.verifyPersonaOwnership(securityToken, personaId);
 
         PersonaEntity personaEntity = personaBO.getPersonaById(personaId);
         List<CarSlotEntity> personasCar = basketBO.getPersonasCar(personaId);
@@ -194,7 +194,7 @@ public class Personas {
     public String carsPost(@PathParam(value = "personaId") Long personaId,
                            @QueryParam("serialNumber") Long serialNumber,
                            @HeaderParam("securityToken") String securityToken) {
-        sessionBO.verifyPersona(securityToken, personaId);
+        sessionBO.verifyPersonaOwnership(securityToken, personaId);
         if (basketBO.sellCar(securityToken, personaId, serialNumber)) {
             OwnedCarTrans ownedCarTrans = personaBO.getDefaultCar(personaId);
             return MarshalXML.marshal(ownedCarTrans);
@@ -233,7 +233,7 @@ public class Personas {
     public String carsPut(@PathParam(value = "personaId") Long personaId,
                           @HeaderParam("securityToken") String securityToken, InputStream ownedCarXml) {
         // update car (skill and performance shop)
-        sessionBO.verifyPersona(securityToken, personaId);
+        sessionBO.verifyPersonaOwnership(securityToken, personaId);
         OwnedCarTrans ownedCarTrans = personaBO.getDefaultCar(personaId);
         return MarshalXML.marshal(ownedCarTrans);
     }
@@ -252,7 +252,7 @@ public class Personas {
     @Produces(MediaType.APPLICATION_XML)
     public String defaultcar(@PathParam(value = "personaId") Long personaId, @PathParam(value = "carId") Long carId,
                              @HeaderParam("securityToken") String securityToken) {
-        sessionBO.verifyPersona(securityToken, personaId);
+        sessionBO.verifyPersonaOwnership(securityToken, personaId);
         personaBO.changeDefaultCar(personaId, carId);
         return "";
     }

--- a/src/main/java/com/soapboxrace/core/api/Security.java
+++ b/src/main/java/com/soapboxrace/core/api/Security.java
@@ -1,18 +1,13 @@
 package com.soapboxrace.core.api;
 
 import com.soapboxrace.core.api.util.Secured;
-import com.soapboxrace.core.bo.TokenSessionBO;
 import com.soapboxrace.jaxb.http.FraudConfig;
 
-import javax.ejb.EJB;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
 @Path("/security")
 public class Security {
-
-    @EJB
-    private TokenSessionBO tokenSessionBO;
 
     @GET
     @Secured
@@ -26,14 +21,5 @@ public class Security {
         fraudConfig.setStartUpFreq(1000000);
         fraudConfig.setUserID(userId);
         return fraudConfig;
-    }
-
-    @POST
-    @Secured
-    @Path("/generateWebToken")
-    @Produces(MediaType.APPLICATION_XML)
-    public String generateWebToken(@HeaderParam("userId") Long userId,
-                                   @HeaderParam("securityToken") String securityToken) {
-        return "<string>" + tokenSessionBO.generateWebToken(userId, securityToken) + "</string>";
     }
 }

--- a/src/main/java/com/soapboxrace/core/bo/BasketBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/BasketBO.java
@@ -338,7 +338,7 @@ public class BasketBO {
     }
 
     public boolean sellCar(String securityToken, Long personaId, Long serialNumber) {
-        this.tokenSessionBO.verifyPersona(securityToken, personaId);
+        this.tokenSessionBO.verifyPersonaOwnership(securityToken, personaId);
 
         OwnedCarEntity ownedCarEntity = ownedCarDAO.findById(serialNumber);
         if (ownedCarEntity == null) {

--- a/src/main/java/com/soapboxrace/core/bo/CommerceBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/CommerceBO.java
@@ -34,9 +34,6 @@ public class CommerceBO {
     private InventoryItemDAO inventoryItemDAO;
 
     @EJB
-    private ParameterBO parameterBO;
-
-    @EJB
     private CustomCarDAO customCarDAO;
 
     @EJB
@@ -44,16 +41,6 @@ public class CommerceBO {
 
     @EJB
     private PerformanceBO performanceBO;
-
-    public OwnedCarTrans responseCar(CommerceSessionTrans commerceSessionTrans) {
-        OwnedCarTrans ownedCarTrans = new OwnedCarTrans();
-        ownedCarTrans.setCustomCar(commerceSessionTrans.getUpdatedCar().getCustomCar());
-        ownedCarTrans.setDurability(commerceSessionTrans.getUpdatedCar().getDurability());
-        ownedCarTrans.setHeat(commerceSessionTrans.getUpdatedCar().getHeat());
-        ownedCarTrans.setId(commerceSessionTrans.getUpdatedCar().getId());
-        ownedCarTrans.setOwnershipType(commerceSessionTrans.getUpdatedCar().getOwnershipType());
-        return ownedCarTrans;
-    }
 
     public CommerceSessionResultTrans doCommerce(CommerceSessionTrans commerceSessionTrans, Long personaId) {
         List<BasketItemTrans> basketItems = commerceSessionTrans.getBasket().getItems().getBasketItemTrans();
@@ -216,97 +203,5 @@ public class CommerceBO {
         commerceSessionResultTrans.setWallets(arrayOfWalletTrans);
 
         return commerceSessionResultTrans;
-    }
-
-    private void addPaint(CustomCarEntity customCarEntity, Object customizationObject, Integer hash) {
-        if (customizationObject instanceof CustomPaintTrans) {
-            CustomPaintTrans customPaintTrans = (CustomPaintTrans) customizationObject;
-            PaintEntity paintEntity = new PaintEntity();
-            paintEntity.setCustomCar(customCarEntity);
-            paintEntity.setGroup(customPaintTrans.getGroup());
-            paintEntity.setHue(customPaintTrans.getHue());
-            paintEntity.setSat(customPaintTrans.getSat());
-            paintEntity.setSlot(customPaintTrans.getSlot());
-            paintEntity.setVar(customPaintTrans.getVar());
-            customCarEntity.getPaints().add(paintEntity);
-        }
-    }
-
-    private void addVinyl(CustomCarEntity customCarEntity, Object customizationObject, Integer hash) {
-        if (customizationObject instanceof CustomVinylTrans) {
-            CustomVinylTrans customVinylTrans = (CustomVinylTrans) customizationObject;
-            VinylEntity vinylEntity = new VinylEntity();
-            vinylEntity.setHash(customVinylTrans.getHash());
-            vinylEntity.setHue1(customVinylTrans.getHue1());
-            vinylEntity.setHue2(customVinylTrans.getHue2());
-            vinylEntity.setHue3(customVinylTrans.getHue3());
-            vinylEntity.setHue4(customVinylTrans.getHue4());
-            vinylEntity.setLayer(customVinylTrans.getLayer());
-            vinylEntity.setMir(customVinylTrans.isMir());
-            vinylEntity.setRot(customVinylTrans.getRot());
-            vinylEntity.setScalex(customVinylTrans.getScaleX());
-            vinylEntity.setScaley(customVinylTrans.getScaleY());
-            vinylEntity.setShear(customVinylTrans.getShear());
-            vinylEntity.setTranx(customVinylTrans.getTranX());
-            vinylEntity.setTrany(customVinylTrans.getTranY());
-            vinylEntity.setVar1(customVinylTrans.getVar1());
-            vinylEntity.setVar2(customVinylTrans.getVar2());
-            vinylEntity.setVar3(customVinylTrans.getVar3());
-            vinylEntity.setVar4(customVinylTrans.getVar4());
-            vinylEntity.setSat1(customVinylTrans.getSat1());
-            vinylEntity.setSat2(customVinylTrans.getSat2());
-            vinylEntity.setSat3(customVinylTrans.getSat3());
-            vinylEntity.setSat4(customVinylTrans.getSat4());
-            vinylEntity.setCustomCar(customCarEntity);
-            customCarEntity.getVinyls().add(vinylEntity);
-        }
-    }
-
-    private void addPerformancePart(CustomCarEntity customCarEntity, Object customizationObject, Integer hash) {
-        if (customizationObject instanceof PerformancePartTrans) {
-            PerformancePartEntity performancePartEntity = new PerformancePartEntity();
-            performancePartEntity.setPerformancePartAttribHash(hash);
-            performancePartEntity.setCustomCar(customCarEntity);
-            customCarEntity.getPerformanceParts().add(performancePartEntity);
-        }
-    }
-
-    private void addSkillPart(CustomCarEntity customCarEntity, Object customizationObject, Integer hash) {
-        if (customizationObject instanceof SkillModPartTrans) {
-            SkillModPartEntity skillModPartEntity = new SkillModPartEntity();
-            skillModPartEntity.setSkillModPartAttribHash(hash);
-            skillModPartEntity.setCustomCar(customCarEntity);
-            customCarEntity.getSkillModParts().add(skillModPartEntity);
-        }
-    }
-
-    private void addVisualPart(CustomCarEntity customCarEntity, Object customizationObject, Integer hash) {
-        if (customizationObject instanceof VisualPartTrans) {
-            VisualPartEntity visualPartEntity = new VisualPartEntity();
-            visualPartEntity.setPartHash(hash);
-            visualPartEntity.setSlotHash(((VisualPartTrans) customizationObject).getSlotHash());
-            visualPartEntity.setCustomCar(customCarEntity);
-            customCarEntity.getVisualParts().add(visualPartEntity);
-        }
-    }
-
-    private Integer calcProductSellPrice(ProductEntity productEntity) {
-        return (int) productEntity.getResalePrice();
-    }
-
-    private void disableItem(ProductEntity productEntity) {
-        Boolean disableItemAfterBuy = parameterBO.getBoolParam("DISABLE_ITEM_AFTER_BUY");
-        if (disableItemAfterBuy) {
-            productEntity.setEnabled(false);
-            productDAO.update(productEntity);
-        }
-    }
-
-    private void disableItem(VinylProductEntity vinylProductEntity) {
-        Boolean disableItemAfterBuy = parameterBO.getBoolParam("DISABLE_ITEM_AFTER_BUY");
-        if (disableItemAfterBuy) {
-            vinylProductEntity.setEnabled(false);
-            vinylProductDAO.update(vinylProductEntity);
-        }
     }
 }

--- a/src/main/java/com/soapboxrace/core/bo/DriverPersonaBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/DriverPersonaBO.java
@@ -49,9 +49,6 @@ public class DriverPersonaBO {
     private InventoryBO inventoryBO;
 
     @EJB
-    private OpenFireRestApiCli restApiCli;
-
-    @EJB
     private PresenceBO presenceBO;
 
     @EJB

--- a/src/main/java/com/soapboxrace/core/bo/InventoryBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/InventoryBO.java
@@ -31,7 +31,7 @@ public class InventoryBO {
     @EJB
     private VirtualItemDAO virtualItemDAO;
 
-    @Schedule(minute = "*/2", hour = "*")
+    @Schedule(minute = "*/2", hour = "*", persistent = false)
     public void removeExpiredItems() {
         for (InventoryItemEntity inventoryItemEntity : inventoryItemDAO.findAllWithExpirationDate()) {
             if (inventoryItemEntity.getExpirationDate().isBefore(LocalDateTime.now())) {

--- a/src/main/java/com/soapboxrace/core/bo/ItemRewardBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/ItemRewardBO.java
@@ -1,7 +1,6 @@
 package com.soapboxrace.core.bo;
 
 import com.soapboxrace.core.bo.util.*;
-import com.soapboxrace.core.dao.CardPackDAO;
 import com.soapboxrace.core.dao.PersonaDAO;
 import com.soapboxrace.core.dao.ProductDAO;
 import com.soapboxrace.core.dao.RewardTableDAO;
@@ -20,7 +19,6 @@ import javax.ejb.Stateless;
 import javax.script.Bindings;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
-import java.security.SecureRandom;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -31,9 +29,6 @@ public class ItemRewardBO {
             ThreadLocal.withInitial(() -> (NashornScriptEngine) new ScriptEngineManager().getEngineByName("nashorn"));
     @EJB
     private PersonaDAO personaDAO;
-
-    @EJB
-    private CardPackDAO cardPackDAO;
 
     @EJB
     private ProductDAO productDAO;
@@ -49,7 +44,6 @@ public class ItemRewardBO {
 
     @EJB
     private BasketBO basketBO;
-    private Random random = new SecureRandom();
 
     public ArrayOfCommerceItemTrans getRewards(Long personaId, String rewardScript) {
         PersonaEntity personaEntity = personaDAO.findById(personaId);

--- a/src/main/java/com/soapboxrace/core/bo/ItemRewardBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/ItemRewardBO.java
@@ -5,7 +5,12 @@ import com.soapboxrace.core.dao.CardPackDAO;
 import com.soapboxrace.core.dao.PersonaDAO;
 import com.soapboxrace.core.dao.ProductDAO;
 import com.soapboxrace.core.dao.RewardTableDAO;
-import com.soapboxrace.core.jpa.*;
+import com.soapboxrace.core.engine.EngineException;
+import com.soapboxrace.core.engine.EngineExceptionCode;
+import com.soapboxrace.core.jpa.PersonaEntity;
+import com.soapboxrace.core.jpa.ProductEntity;
+import com.soapboxrace.core.jpa.RewardTableEntity;
+import com.soapboxrace.core.jpa.RewardTableItemEntity;
 import com.soapboxrace.jaxb.http.ArrayOfCommerceItemTrans;
 import com.soapboxrace.jaxb.http.CommerceItemTrans;
 import jdk.nashorn.api.scripting.NashornScriptEngine;
@@ -17,6 +22,7 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.security.SecureRandom;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Stateless
@@ -72,7 +78,15 @@ public class ItemRewardBO {
     }
 
     private ItemRewardBase scriptToItem(String rewardScript, Bindings bindings) throws ScriptException {
-        return (ItemRewardBase) scriptEngine.get().eval(rewardScript, bindings);
+        Object obj = scriptEngine.get().eval(rewardScript, bindings);
+
+        if (obj instanceof ItemRewardBase) {
+            return (ItemRewardBase) obj;
+        } else if (obj instanceof RewardBuilder) {
+            return ((RewardBuilder) obj).build();
+        }
+
+        throw new RuntimeException("Invalid script return: " + obj.getClass().getName());
     }
 
     private void handleReward(ItemRewardBase itemRewardBase, ArrayOfCommerceItemTrans arrayOfCommerceItemTrans,
@@ -129,265 +143,278 @@ public class ItemRewardBO {
     }
 
     /**
-     * Helper class for generating {@link ItemRewardBase} objects
+     * Exposes access to builder objects for rewards.
      */
     public class RewardGenerator {
         /**
-         * Finds the product with the given entitlement tag and returns it as an {@link ItemRewardProduct}
+         * Creates a cash reward builder
          *
-         * @param entitlementTag The entitlement tag of the desired product
-         * @return The {@link ItemRewardProduct} instance containing the desired product
+         * @return The builder instance
          */
-        public ItemRewardProduct generateSingleItem(String entitlementTag) {
-            ProductEntity byEntitlementTag = productDAO.findByEntitlementTag(entitlementTag);
-
-            if (byEntitlementTag == null) {
-                throw new IllegalArgumentException("Invalid entitlementTag: " + entitlementTag);
-            }
-
-            return new ItemRewardProduct(byEntitlementTag);
+        public CashRewardBuilder cash() {
+            return new CashRewardBuilder();
         }
 
-        public ItemRewardMultiProduct multiItems(String[] entitlementTags) {
-            List<ProductEntity> productEntities = new ArrayList<>();
-
-            for (String entitlementTag : entitlementTags) {
-                ProductEntity byEntitlementTag = productDAO.findByEntitlementTag(entitlementTag);
-
-                if (byEntitlementTag == null) {
-                    throw new IllegalArgumentException("Invalid entitlementTag: " + entitlementTag);
-                }
-
-                productEntities.add(byEntitlementTag);
-            }
-
-            return new ItemRewardMultiProduct(productEntities);
+        /**
+         * Creates a random reward builder
+         *
+         * @return The builder instance
+         */
+        public RandomSelectionBuilder random() {
+            return new RandomSelectionBuilder();
         }
 
-        public ItemRewardProduct randomDrop(String[] entitlementTags) {
-            List<ProductEntity> productEntities = new ArrayList<>();
+        /**
+         * Creates a product reward builder
+         *
+         * @return The builder instance
+         */
+        public ProductSelectionBuilder product() {
+            return new ProductSelectionBuilder();
+        }
 
-            for (String entitlementTag : entitlementTags) {
-                ProductEntity byEntitlementTag = productDAO.findByEntitlementTag(entitlementTag);
+        /**
+         * Creates a table reward builder
+         *
+         * @return The builder instance
+         */
+        public TableSelectionBuilder table() {
+            return new TableSelectionBuilder();
+        }
+    }
 
-                if (byEntitlementTag == null) {
-                    throw new IllegalArgumentException("Invalid entitlementTag: " + entitlementTag);
-                }
+    /**
+     * Reward builder for cash rewards
+     */
+    public class CashRewardBuilder extends RewardBuilder<ItemRewardCash> {
 
-                productEntities.add(byEntitlementTag);
+        private int cash;
+
+        /**
+         * Sets the cash amount of the reward
+         *
+         * @param cash The cash amount
+         * @return The updated builder
+         */
+        public CashRewardBuilder amount(int cash) {
+            this.cash = cash;
+            return this;
+        }
+
+        @Override
+        public ItemRewardCash build() {
+            return new ItemRewardCash(this.cash);
+        }
+    }
+
+    /**
+     * Reward builder for random selections
+     */
+    public class RandomSelectionBuilder extends RewardBuilder<ItemRewardBase> {
+
+        private List<ItemRewardBase> choices;
+
+        public RandomSelectionBuilder withChoices(List<ItemRewardBase> choices) {
+            this.choices = choices;
+            return this;
+        }
+
+        public RandomSelectionBuilder withBuilders(List<RewardBuilder> choices) {
+            this.choices =
+                    choices.stream().map((Function<RewardBuilder, ItemRewardBase>) RewardBuilder::build).collect(Collectors.toList());
+            return this;
+        }
+
+        @Override
+        public ItemRewardBase build() {
+            Objects.requireNonNull(this.choices);
+            return this.choices.get(new Random().nextInt(this.choices.size()));
+        }
+    }
+
+    /**
+     * Reward builder for product selections
+     */
+    public class ProductSelectionBuilder extends RewardBuilder<ItemRewardProduct> {
+
+        private boolean isWeighted;
+
+        private String entitlementTag;
+
+        private String category;
+
+        private String productType;
+
+        private String subType;
+
+        private Integer rating;
+
+        private Integer quantity = -1;
+
+        public ProductSelectionBuilder category(String category) {
+            this.category = category;
+            return this;
+        }
+
+        public ProductSelectionBuilder weighted(boolean isWeighted) {
+            this.isWeighted = isWeighted;
+            return this;
+        }
+
+        public ProductSelectionBuilder type(String productType) {
+            this.productType = productType;
+            return this;
+        }
+
+        public ProductSelectionBuilder subType(String subType) {
+            this.subType = subType;
+            return this;
+        }
+
+        public ProductSelectionBuilder rating(Integer rating) {
+            this.rating = rating;
+            return this;
+        }
+
+        public ProductSelectionBuilder quantity(Integer quantity) {
+            if (quantity < -1) {
+                throw new IllegalArgumentException("quantity < -1");
             }
+
+            this.quantity = quantity;
+            return this;
+        }
+
+        public ProductSelectionBuilder entitlementTag(String entitlementTag) {
+            this.entitlementTag = entitlementTag;
+            return this;
+        }
+
+        @Override
+        public ItemRewardQuantityProduct build() {
+            if (this.entitlementTag != null && !this.entitlementTag.isEmpty()) {
+                return new ItemRewardQuantityProduct(productDAO.findByEntitlementTag(this.entitlementTag),
+                        this.quantity);
+            }
+
+            List<ProductEntity> productEntities = productDAO.findByTraits(
+                    this.category,
+                    this.productType,
+                    this.subType,
+                    this.rating
+            );
 
             if (productEntities.isEmpty()) {
-                throw new IllegalArgumentException("No products to choose from!");
+                throw new RuntimeException("No products to choose from! " + String.format("PT=%s ST=%s R=%d",
+                        this.productType, this.subType, this.rating));
             }
 
-            return new ItemRewardProduct(productEntities.get(random.nextInt(productEntities.size())));
-        }
+            if (this.isWeighted) {
+                double weightSum =
+                        productEntities.stream().mapToDouble(p -> OptionalDouble.of(p.getDropWeight()).orElse(1.0d / productEntities.size())).sum();
 
-        public ItemRewardProduct randomDrop(List<String> entitlementTags) {
-            List<ProductEntity> productEntities = new ArrayList<>();
+                int randomIndex = -1;
+                double random = Math.random() * weightSum;
 
-            for (String entitlementTag : entitlementTags) {
-                ProductEntity byEntitlementTag = productDAO.findByEntitlementTag(entitlementTag);
+                for (int i = 0; i < productEntities.size(); i++) {
+                    random -= OptionalDouble.of(productEntities.get(i).getDropWeight()).orElse(1.0d / productEntities.size());
 
-                if (byEntitlementTag == null) {
-                    throw new IllegalArgumentException("Invalid entitlementTag: " + entitlementTag);
+                    if (random <= 0.0d) {
+                        randomIndex = i;
+                        break;
+                    }
                 }
 
-                productEntities.add(byEntitlementTag);
-            }
-
-            if (productEntities.isEmpty()) {
-                throw new IllegalArgumentException("No products to choose from!");
-            }
-
-            return new ItemRewardProduct(productEntities.get(random.nextInt(productEntities.size())));
-        }
-
-        public ItemRewardBase randomSelection(List<ItemRewardBase> rewards) {
-            if (rewards.isEmpty()) {
-                throw new IllegalArgumentException("No rewards to choose from!");
-            }
-
-            return rewards.get(random.nextInt(rewards.size()));
-        }
-
-        public ItemRewardCash cashReward(Integer cashAmount) {
-            return new ItemRewardCash(cashAmount);
-        }
-
-        public ItemRewardQuantityProduct rewardQuantityProduct(String entitlementTag, Integer quantity) {
-            ProductEntity byEntitlementTag = productDAO.findByEntitlementTag(entitlementTag);
-
-            if (byEntitlementTag == null) {
-                throw new IllegalArgumentException("Invalid entitlementTag: " + entitlementTag);
-            }
-
-            return new ItemRewardQuantityProduct(byEntitlementTag, quantity);
-        }
-
-        public ItemRewardMulti multipleRewards(ItemRewardBase[] rewards) {
-            return new ItemRewardMulti(Arrays.asList(rewards));
-        }
-
-        // special item finders
-        public ItemRewardProduct findRandomRatedItem(String type, Integer rating) {
-            List<ProductEntity> productEntities = productDAO.findDropsBySubTypeAndRarity(type, rating);
-            try {
-                return randomDrop(productEntities.stream().map(ProductEntity::getEntitlementTag).collect(Collectors.toList()));
-            } catch (Exception e) {
-                throw new RuntimeException("findRandomRatedItem() failed for: " + type + ", " + rating, e);
-            }
-        }
-
-        public ItemRewardProduct findRandomRatedItemByProdType(String type, Integer rating) {
-            List<ProductEntity> productEntities = productDAO.findDropsByProdTypeAndRarity(type, rating);
-            try {
-                return randomDrop(productEntities.stream().map(ProductEntity::getEntitlementTag).collect(Collectors.toList()));
-            } catch (Exception e) {
-                throw new RuntimeException("findRandomRatedItemByProdType() failed for: " + type + ", " + rating, e);
-            }
-        }
-
-        public ItemRewardProduct findRandomItemByProdType(String type) {
-            List<ProductEntity> productEntities = productDAO.findDropsByType(type);
-            try {
-                return randomDrop(productEntities.stream().map(ProductEntity::getEntitlementTag).collect(Collectors.toList()));
-            } catch (Exception e) {
-                throw new RuntimeException("findRandomItemByProdType() failed for: " + type + " (products: " + productEntities.size() + ")");
-            }
-        }
-
-        public ItemRewardProduct findWeightedRandomItemByProdType(String type) {
-            List<ProductEntity> productEntities = productDAO.findDropsByType(type);
-
-            if (productEntities.isEmpty()) {
-                throw new IllegalArgumentException("No products to choose from of type " + type);
-            }
-
-            double weightSum =
-                    productEntities.stream().mapToDouble(p -> this.getDropWeight(p
-                            , productEntities)).sum();
-
-            int randomIndex = -1;
-            double random = Math.random() * weightSum;
-
-            for (int i = 0; i < productEntities.size(); i++) {
-                random -= this.getDropWeight(productEntities.get(i), productEntities);
-
-                if (random <= 0.0d) {
-                    randomIndex = i;
-                    break;
+                if (randomIndex == -1) {
+                    throw new RuntimeException("Weighted random failed! " + String.format("PT=%s ST=%s R=%d",
+                            this.productType, this.subType, this.rating));
                 }
+
+                return new ItemRewardQuantityProduct(productEntities.get(randomIndex), quantity);
             }
 
-            if (randomIndex == -1) {
-                throw new RuntimeException("Random selection failed for type " + type);
-            }
+            return new ItemRewardQuantityProduct(
+                    productEntities.get(new Random().nextInt(productEntities.size())),
+                    quantity);
+        }
+    }
 
-            return new ItemRewardProduct(productEntities.get(randomIndex));
+    /**
+     * Reward builder for table selections
+     */
+    public class TableSelectionBuilder extends RewardBuilder<ItemRewardBase> {
+
+        private String tableName;
+
+        private boolean weighted = false;
+
+        public TableSelectionBuilder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
         }
 
-        private double getDropWeight(ProductEntity p, List<ProductEntity> productEntities) {
-            if (p.getDropWeight() == null) {
-                return 1.0d / productEntities.size();
-            }
-
-            return p.getDropWeight();
+        public TableSelectionBuilder weighted(boolean weighted) {
+            this.weighted = weighted;
+            return this;
         }
 
-        private double getDropWeight(RewardTableItemEntity i, List<RewardTableItemEntity> items) {
-            if (i.getDropWeight() == null) {
-                return 1.0d / items.size();
+        @Override
+        public ItemRewardBase build() {
+            Objects.requireNonNull(this.tableName);
+
+            RewardTableEntity rewardTableEntity = rewardTableDAO.findByName(this.tableName);
+
+            Objects.requireNonNull(rewardTableEntity, this.tableName + " not found!");
+
+            List<RewardTableItemEntity> items = rewardTableEntity.getItems();
+
+            if (items.isEmpty()) {
+                throw new EngineException("No items are available in table " + this.tableName,
+                        EngineExceptionCode.LuckyDrawContextNotFoundOrEmpty);
             }
 
-            return i.getDropWeight();
-        }
+            if (this.weighted) {
+                double weightSum =
+                        items.stream().mapToDouble(p -> OptionalDouble.of(p.getDropWeight()).orElse(1.0d / items.size())).sum();
 
-        public ItemRewardMulti getCardPack(String cardPackId) {
-            List<ItemRewardBase> items = new ArrayList<>();
-            CardPackEntity cardPackEntity = cardPackDAO.findByEntitlementTag(cardPackId);
+                int randomIndex = -1;
+                double random = Math.random() * weightSum;
 
-            for (CardPackItemEntity cardPackItemEntity : cardPackEntity.getItems()) {
+                for (int i = 0; i < items.size(); i++) {
+                    random -= OptionalDouble.of(items.get(i).getDropWeight()).orElse(1.0d / items.size());
+
+                    if (random <= 0.0d) {
+                        randomIndex = i;
+                        break;
+                    }
+                }
+
+                if (randomIndex == -1) {
+                    throw new EngineException("Weighted random failed for " + this.tableName,
+                            EngineExceptionCode.LuckyDrawCouldNotDrawProduct);
+                }
+
                 try {
-                    items.add(scriptToItem(cardPackItemEntity.getScript()));
+                    return scriptToItem(items.get(randomIndex).getScript());
                 } catch (ScriptException e) {
-                    throw new RuntimeException("Error while generating card pack " + cardPackId, e);
+                    throw new EngineException(e, EngineExceptionCode.LuckyDrawCouldNotDrawProduct);
                 }
             }
 
-            return new ItemRewardMulti(items);
-        }
-
-        public ItemRewardBase randomTableItem(String tableId) {
             try {
-                return randomTableItem(rewardTableDAO.findByName(tableId).getId());
-            } catch (Exception e) {
-                throw new RuntimeException("Error while doing weighted random for " + tableId, e);
-            }
-        }
-
-        public ItemRewardBase randomTableItem(Long tableId) {
-            RewardTableEntity rewardTableEntity = rewardTableDAO.findByID(tableId);
-            List<RewardTableItemEntity> items = rewardTableEntity.getItems();
-
-            if (items.isEmpty()) {
-                throw new IllegalArgumentException("No items to choose from in table " + tableId);
-            }
-
-            try {
-                return scriptToItem(items.get(random.nextInt(items.size())).getScript());
+                return scriptToItem(items.get(new Random().nextInt(items.size())).getScript());
             } catch (ScriptException e) {
-                throw new RuntimeException(e);
+                throw new EngineException(e, EngineExceptionCode.LuckyDrawCouldNotDrawProduct);
             }
         }
+    }
 
-        public ItemRewardBase weightedRandomTableItem(Long tableId) {
-            RewardTableEntity rewardTableEntity = rewardTableDAO.findByID(tableId);
-            Objects.requireNonNull(rewardTableEntity);
-
-            List<RewardTableItemEntity> items = rewardTableEntity.getItems();
-
-            if (items.isEmpty()) {
-                throw new IllegalArgumentException("No items to choose from in table " + tableId);
-            }
-
-            double weightSum =
-                    items.stream().mapToDouble(i -> this.getDropWeight(i,
-                            items)).sum();
-            int randomIndex = -1;
-            double random = Math.random() * weightSum;
-
-            for (int i = 0; i < items.size(); i++) {
-                random -= this.getDropWeight(items.get(i), items);
-
-                if (random <= 0.0d) {
-                    randomIndex = i;
-                    break;
-                }
-            }
-
-            if (randomIndex == -1) {
-                throw new RuntimeException("Random selection failed for table " + tableId + ".");
-            }
-
-            try {
-                return scriptToItem(items.get(randomIndex).getScript());
-            } catch (ScriptException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        public ItemRewardBase weightedRandomTableItem(String tableId) {
-            RewardTableEntity rewardTableEntity = rewardTableDAO.findByName(tableId);
-
-            Objects.requireNonNull(rewardTableEntity);
-
-            try {
-                return weightedRandomTableItem(rewardTableEntity.getId());
-            } catch (Exception e) {
-                throw new RuntimeException("Error while doing weighted random for " + tableId, e);
-            }
-        }
+    /**
+     * Base class for a reward builder
+     *
+     * @param <T> Reward object type
+     */
+    private abstract class RewardBuilder<T extends ItemRewardBase> {
+        public abstract T build();
     }
 }

--- a/src/main/java/com/soapboxrace/core/bo/ItemRewardBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/ItemRewardBO.java
@@ -304,9 +304,10 @@ public class ItemRewardBO {
                     this.rating
             );
 
+            String debugFormat = String.format("C=%s PT=%s ST=%s R=%d",
+                    this.category, this.productType, this.subType, this.rating);
             if (productEntities.isEmpty()) {
-                throw new RuntimeException("No products to choose from! " + String.format("PT=%s ST=%s R=%d",
-                        this.productType, this.subType, this.rating));
+                throw new RuntimeException("No products to choose from! " + debugFormat);
             }
 
             if (this.isWeighted) {
@@ -326,8 +327,7 @@ public class ItemRewardBO {
                 }
 
                 if (randomIndex == -1) {
-                    throw new RuntimeException("Weighted random failed! " + String.format("PT=%s ST=%s R=%d",
-                            this.productType, this.subType, this.rating));
+                    throw new RuntimeException("Weighted random failed! " + debugFormat);
                 }
 
                 return new ItemRewardQuantityProduct(productEntities.get(randomIndex), quantity);

--- a/src/main/java/com/soapboxrace/core/bo/RewardBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/RewardBO.java
@@ -156,7 +156,8 @@ public class RewardBO {
 
     private LuckyDrawItem getLuckyDrawItem(PersonaEntity personaEntity, RewardTableEntity rewardTableEntity) {
         LuckyDrawItem luckyDrawItem = new LuckyDrawItem();
-        ItemRewardBase rewardBase = itemRewardBO.getGenerator().weightedRandomTableItem(rewardTableEntity.getId());
+        ItemRewardBase rewardBase = itemRewardBO.getGenerator().table().tableName(rewardTableEntity.getName()).build();
+//        ItemRewardBase rewardBase = itemRewardBO.getGenerator().weightedRandomTableItem(rewardTableEntity.getId());
 
         if (rewardBase instanceof ItemRewardProduct) {
             ItemRewardProduct rewardProduct = (ItemRewardProduct) rewardBase;
@@ -172,7 +173,14 @@ public class RewardBO {
                     driverPersonaBO.updateCash(personaEntity, cash + resalePrice);
                 }
             } else {
-                inventoryBO.addFromCatalog(productEntity, personaEntity);
+                Integer quantity = -1;
+
+                if (rewardBase instanceof ItemRewardQuantityProduct) {
+                    quantity = ((ItemRewardQuantityProduct) rewardBase).getUseCount();
+                }
+
+                luckyDrawItem.setRemainingUseCount(quantity == -1 ? productEntity.getUseCount() : quantity);
+                inventoryBO.addFromCatalog(productEntity, personaEntity, quantity);
             }
         } else if (rewardBase instanceof ItemRewardCash) {
             ItemRewardCash rewardCash = (ItemRewardCash) rewardBase;

--- a/src/main/java/com/soapboxrace/core/bo/RewardBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/RewardBO.java
@@ -60,7 +60,7 @@ public class RewardBO {
         return (long) (personaEntity.getRepAtCurrentLevel() + exp) >= levelRepDao.findByLevel((long) personaEntity.getLevel()).getExpPoint();
     }
 
-    public LuckyDrawInfo getLuckyDrawInfo(Integer rank, Integer level, PersonaEntity personaEntity,
+    public LuckyDrawInfo getLuckyDrawInfo(Integer rank, PersonaEntity personaEntity,
                                           EventEntity eventEntity) {
         LuckyDrawInfo luckyDrawInfo = new LuckyDrawInfo();
         if (!parameterBO.getBoolParam("ENABLE_DROP_ITEM")) {
@@ -156,8 +156,8 @@ public class RewardBO {
 
     private LuckyDrawItem getLuckyDrawItem(PersonaEntity personaEntity, RewardTableEntity rewardTableEntity) {
         LuckyDrawItem luckyDrawItem = new LuckyDrawItem();
-        ItemRewardBase rewardBase = itemRewardBO.getGenerator().table().tableName(rewardTableEntity.getName()).build();
-//        ItemRewardBase rewardBase = itemRewardBO.getGenerator().weightedRandomTableItem(rewardTableEntity.getId());
+        ItemRewardBase rewardBase =
+                itemRewardBO.getGenerator().table().tableName(rewardTableEntity.getName()).weighted(true).build();
 
         if (rewardBase instanceof ItemRewardProduct) {
             ItemRewardProduct rewardProduct = (ItemRewardProduct) rewardBase;
@@ -318,7 +318,7 @@ public class RewardBO {
         Accolades accolades = new Accolades();
         accolades.setFinalRewards(getFinalReward(rewardVO.getRep(), rewardVO.getCash()));
         accolades.setHasLeveledUp(isLeveledUp(personaEntity, rewardVO.getRep()));
-        accolades.setLuckyDrawInfo(getLuckyDrawInfo(arbitrationPacket.getRank(), personaEntity.getLevel(),
+        accolades.setLuckyDrawInfo(getLuckyDrawInfo(arbitrationPacket.getRank(),
                 personaEntity, eventEntity));
         accolades.setOriginalRewards(getFinalReward(rewardVO.getRep(), rewardVO.getCash()));
         accolades.setRewardInfo(rewardVO.getArrayOfRewardPart());

--- a/src/main/java/com/soapboxrace/core/bo/TokenSessionBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/TokenSessionBO.java
@@ -52,13 +52,6 @@ public class TokenSessionBO {
         return true;
     }
 
-    public void updateToken(String securityToken) {
-        TokenSessionEntity tokenSessionEntity = tokenDAO.findById(securityToken);
-        Date expirationDate = getMinutes(3);
-        tokenSessionEntity.setExpirationDate(expirationDate);
-        tokenDAO.update(tokenSessionEntity);
-    }
-
     public String createToken(Long userId, String clientHostName) {
         TokenSessionEntity tokenSessionEntity = new TokenSessionEntity();
         Date expirationDate = getMinutes(15);
@@ -74,20 +67,7 @@ public class TokenSessionBO {
         return randomUUID;
     }
 
-    public String generateWebToken(Long userId, String securityToken) {
-        TokenSessionEntity tokenSessionEntity = tokenDAO.findById(securityToken);
-
-        if (tokenSessionEntity == null) {
-            throw new EngineException(EngineExceptionCode.NoSuchSessionInSessionStore);
-        }
-
-        tokenSessionEntity.setWebToken(UUIDGen.getRandomUUID());
-        tokenDAO.update(tokenSessionEntity);
-
-        return tokenSessionEntity.getWebToken();
-    }
-
-    public boolean verifyPersona(String securityToken, Long personaId) {
+    public void verifyPersonaOwnership(String securityToken, Long personaId) {
         TokenSessionEntity tokenSession = tokenDAO.findById(securityToken);
         if (tokenSession == null) {
             throw new EngineException(EngineExceptionCode.NoSuchSessionInSessionStore);
@@ -96,7 +76,6 @@ public class TokenSessionBO {
         if (!tokenSession.getUserEntity().ownsPersona(personaId)) {
             throw new EngineException(EngineExceptionCode.RemotePersonaDoesNotBelongToUser);
         }
-        return true;
     }
 
     public void deleteByUserId(Long userId) {
@@ -106,11 +85,10 @@ public class TokenSessionBO {
     private Date getMinutes(int minutes) {
         long time = new Date().getTime();
         time = time + (minutes * 60000);
-        Date date = new Date(time);
-        return date;
+        return new Date(time);
     }
 
-    public LoginStatusVO checkGeoIp(String ip) {
+    private LoginStatusVO checkGeoIp(String ip) {
         LoginStatusVO loginStatusVO = new LoginStatusVO(0L, "", false);
         String allowedCountries = serverInfoBO.getServerInformation().getAllowedCountries();
         if (allowedCountries != null && !allowedCountries.isEmpty()) {
@@ -202,10 +180,6 @@ public class TokenSessionBO {
         TokenSessionEntity tokenSessionEntity = tokenDAO.findById(securityToken);
         tokenSessionEntity.setActiveLobbyId(lobbyId);
         tokenDAO.update(tokenSessionEntity);
-    }
-
-    public boolean isPremium(String securityToken) {
-        return tokenDAO.findById(securityToken).isPremium();
     }
 
     public boolean isAdmin(String securityToken) {

--- a/src/main/java/com/soapboxrace/core/bo/util/ItemRewardQuantityProduct.java
+++ b/src/main/java/com/soapboxrace/core/bo/util/ItemRewardQuantityProduct.java
@@ -5,6 +5,11 @@ import com.soapboxrace.core.jpa.ProductEntity;
 public class ItemRewardQuantityProduct extends ItemRewardProduct {
     private Integer useCount;
 
+    public ItemRewardQuantityProduct(ProductEntity productEntity) {
+        super(productEntity);
+        this.useCount = -1;
+    }
+
     public ItemRewardQuantityProduct(ProductEntity productEntity, Integer useCount) {
         super(productEntity);
         this.useCount = useCount;

--- a/src/main/java/com/soapboxrace/core/dao/InventoryItemDAO.java
+++ b/src/main/java/com/soapboxrace/core/dao/InventoryItemDAO.java
@@ -87,4 +87,11 @@ public class InventoryItemDAO extends BaseDAO<InventoryItemEntity> {
             delete(inventoryItemEntity);
         }
     }
+
+    @Override
+    public void insert(InventoryItemEntity entity) {
+        super.insert(entity);
+
+        System.out.println("InventoryItemDAO insert() called");
+    }
 }

--- a/src/main/java/com/soapboxrace/core/jpa/AchievementRankEntity.java
+++ b/src/main/java/com/soapboxrace/core/jpa/AchievementRankEntity.java
@@ -22,7 +22,7 @@ public class AchievementRankEntity {
     @Column
     private Integer points;
 
-    @Column
+    @Column(name = "`rank`")
     private Integer rank;
 
     @Column

--- a/src/main/java/com/soapboxrace/core/jpa/EventDataEntity.java
+++ b/src/main/java/com/soapboxrace/core/jpa/EventDataEntity.java
@@ -54,6 +54,7 @@ public class EventDataEntity {
     private long eventDurationInMilliseconds;
     private int finishReason;
     private long hacksDetected;
+    @Column(name = "`rank`")
     private int rank;
 
     public Long getId() {


### PR DESCRIPTION
This PR introduces a new reward generator API (for achievements/card packs/whatever), with an emphasis on _readability_.

Old expressions:
`generator.randomSelection([generator.weightedRandomTableItem('powerups_low'),generator.weightedRandomTableItem('powerups_medium'),generator.weightedRandomTableItem('powerups_high')])`
`generator.findWeightedRandomItemByProdType('visualpart')`
New expressions:
```
generator.random().withBuilders([
    generator.table().tableName("powerups_low").weighted(true),
    generator.table().tableName("powerups_medium").weighted(true),
    generator.table().tableName("powerups_high").weighted(true)
])
```
`generator.product().weighted(true).type('visualpart')`

This system should make it much easier to create rewards, because it is no longer necessary to create new methods for every possible requirement.

This PR also includes some code cleanup that got mixed in somehow. Can't go wrong with some code cleanup.