### PR TITLE
[DriverPersonaBO] Add blacklisted driver names through server parameters

### DIFF
--- a/src/main/java/com/soapboxrace/core/bo/DriverPersonaBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/DriverPersonaBO.java
@@ -218,6 +218,15 @@ public class DriverPersonaBO {
 
     public ArrayOfString reserveName(String name) {
         ArrayOfString arrayOfString = new ArrayOfString();
+        if (Boolean.TRUE.equals(parameterBO.getBoolParam("ENABLE_PERSONA_NAME_BLACKLIST"))) {
+            String[] personaNameBlacklist = parameterBO.getStrParam("PERSONA_NAME_BLACKLIST").split(";");
+
+            for (String personaName : personaNameBlacklist) {
+                if (personaName.equals(name)) {
+                    arrayOfString.getString().add("NONE");
+                }
+            }
+        }
         if (personaDao.findByName(name) != null) {
             arrayOfString.getString().add("NONE");
         }

--- a/src/main/java/com/soapboxrace/core/bo/DriverPersonaBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/DriverPersonaBO.java
@@ -218,14 +218,8 @@ public class DriverPersonaBO {
 
     public ArrayOfString reserveName(String name) {
         ArrayOfString arrayOfString = new ArrayOfString();
-        if (Boolean.TRUE.equals(parameterBO.getBoolParam("ENABLE_PERSONA_NAME_BLACKLIST"))) {
-            String[] personaNameBlacklist = parameterBO.getStrParam("PERSONA_NAME_BLACKLIST").split(";");
-
-            for (String personaName : personaNameBlacklist) {
-                if (personaName.equals(name)) {
-                    arrayOfString.getString().add("NONE");
-                }
-            }
+        if (Boolean.TRUE.equals(parameterBO.getBoolParam("ENABLE_PERSONA_NAME_BLACKLIST")) && !parameterBO.getStrParam("PERSONA_NAME_BLACKLIST").contains(name)) {
+            arrayOfString.getString().add("NONE");
         }
         if (personaDao.findByName(name) != null) {
             arrayOfString.getString().add("NONE");


### PR DESCRIPTION
This feature allows server owners to enable and set a blacklist of driver persona names from server parameter that will prevent users who create new drivers to use them (will notify the user that the name is taken even though it really isn't).

A good few examples of those names are: ADMIN,DEVELOPER,MODERATOR,SERVER,SYSTEM

Tested and working properly on Underground Stage server