### PR TITLE
[DriverPersonaBO.java] Added parameter option to enable and set black…

### DIFF
--- a/src/main/java/com/soapboxrace/core/api/util/LaunchFilter.java
+++ b/src/main/java/com/soapboxrace/core/api/util/LaunchFilter.java
@@ -99,7 +99,6 @@ public class LaunchFilter implements ContainerRequestFilter {
                 String signedLaunchersCert = parameterBO.getStrParam("SIGNED_LAUNCHER_CERTIFICATE", "");    
                 String signedLaunchersHash = parameterBO.getStrParam("SIGNED_LAUNCHER_HASH", "");
                 String signedLaunchersHwid = parameterBO.getStrParam("SIGNED_LAUNCHER_HWID_WHITELIST", "");
-                String userLauncherCert = "";
                 String userLauncherHash = requestContext.getHeaderString("X-GameLauncherHash");
                 if (signedLaunchersHwid.contains(hwid)) {
                     lock_access = false;
@@ -107,7 +106,8 @@ public class LaunchFilter implements ContainerRequestFilter {
                     ua_split = get_useragent.split(" ");
                     String[] uaVerSplit = ua_split[1].split("\\.");
                     if (requestContext.getHeaderString("X-GameLauncherCertificate") != null) {
-                        if (Boolean.TRUE.equals(signedLaunchersHash.contains(ua_split[1])) && !Boolean.TRUE.equals(signedLaunchersCert.contains(userLauncherCert))) {
+                        String userLauncherCert = requestContext.getHeaderString("X-GameLauncherCertificate");
+                        if (Boolean.TRUE.equals(signedLaunchersHash.contains(ua_split[1])) && !Boolean.TRUE.equals(signedLaunchersCert.equals(userLauncherCert))) {
                             lock_access = true;
                             lock_unsigned = true;
                         } else if (!Boolean.TRUE.equals(signedLaunchersHash.contains(userLauncherHash))) {

--- a/src/main/java/com/soapboxrace/core/api/util/LaunchFilter.java
+++ b/src/main/java/com/soapboxrace/core/api/util/LaunchFilter.java
@@ -99,7 +99,6 @@ public class LaunchFilter implements ContainerRequestFilter {
                 String signedLaunchersCert = parameterBO.getStrParam("SIGNED_LAUNCHER_CERTIFICATE", "");    
                 String signedLaunchersHash = parameterBO.getStrParam("SIGNED_LAUNCHER_HASH", "");
                 String signedLaunchersHwid = parameterBO.getStrParam("SIGNED_LAUNCHER_HWID_WHITELIST", "");
-                // This needs to be predefined else we'll get a big fat NullPointerException up our ass if the user launcher version is < 2.1.8.0
                 String userLauncherCert = "";
                 String userLauncherHash = requestContext.getHeaderString("X-GameLauncherHash");
                 if (signedLaunchersHwid.contains(hwid)) {

--- a/src/main/java/com/soapboxrace/core/bo/DriverPersonaBO.java
+++ b/src/main/java/com/soapboxrace/core/bo/DriverPersonaBO.java
@@ -218,6 +218,16 @@ public class DriverPersonaBO {
 
     public ArrayOfString reserveName(String name) {
         ArrayOfString arrayOfString = new ArrayOfString();
+        // #92: Option to blacklist persona names, returns arrayOfString so it will not run an extra query if the requested driver name is blacklisted
+        if (Boolean.TRUE.equals(parameterBO.getBoolParam("ENABLE_PERSONA_NAME_BLACKLIST"))) {
+            String[] personaNameBlacklist = parameterBO.getStrParam("PERSONA_NAME_BLACKLIST").split(";");
+            for (String personaName : personaNameBlacklist) {
+                if (personaName.equals(name)) {
+                    arrayOfString.getString().add("NONE");
+                    return arrayOfString;
+                }
+            }
+        }
         if (personaDao.findByName(name) != null) {
             arrayOfString.getString().add("NONE");
         }


### PR DESCRIPTION
…list for driver names

This feature allows server owners to enable and set a blacklist of driver persona names from server parameter that will prevent users who create new drivers to use them (will notify the user that the name is taken even though it really isn't).

A good few examples of those names are: ADMIN,DEVELOPER,MODERATOR,SERVER,SYSTEM

Tested and working properly on Underground Stage server

UPDATE 3: Corrected a burnt-out typo of mine and revered back to the .equals() way since we do not want people with substrings of the blacklisted names (such as ADMI) to also be accounted. Added an extra return of arrayOfString from the blacklist check statement so the code will not execute an extra query if the requested driver name is blacklisted

ENABLE_PERSONA_NAME_BLACKLIST='true'
PERSONA_NAME_BLACKLIST='ADMIN;DEVELOPER;MODERATOR;SERVER;SYSTEM'

![1](https://user-images.githubusercontent.com/54352886/134297755-360a618a-94f6-408f-a748-8905528ad9fa.jpg)
![2](https://user-images.githubusercontent.com/54352886/134297760-c6ab301c-1e2b-44c1-b607-b0b95678111c.jpg)
![3](https://user-images.githubusercontent.com/54352886/134297761-a0825520-8467-44bd-8bcb-da35baf740e2.jpg)
